### PR TITLE
Extract serialization

### DIFF
--- a/py2k/models.py
+++ b/py2k/models.py
@@ -85,10 +85,6 @@ class KafkaModel(BaseModel):
     def schema_from_iter(iterator: IterableAdapter):
         return list(itertools.islice(iterator, 1))[0].schema_json()
 
-    @property
-    def value_schema_string(self):
-        return self.schema_json()
-
 
 class DynamicKafkaModel:
     """ class model for automatic serialization of Pandas DataFrame to

--- a/py2k/models.py
+++ b/py2k/models.py
@@ -59,12 +59,6 @@ class KafkaModel(BaseModel):
             datetime.datetime: lambda v: str(v),
         }
 
-        @classmethod
-        def alias_generator(cls, string: str) -> str:
-            # this is the same as `alias_generator = to_camel` above
-            return string
-            # return ''.join(word.capitalize() for word in string.split('_'))
-
         @staticmethod
         def schema_extra(schema: Dict[str, Any],
                          model: Type['KafkaModel']) -> None:

--- a/py2k/models.py
+++ b/py2k/models.py
@@ -85,6 +85,10 @@ class KafkaModel(BaseModel):
     def schema_from_iter(iterator: IterableAdapter):
         return list(itertools.islice(iterator, 1))[0].schema_json()
 
+    @property
+    def value_schema_string(self):
+        return self.schema_json()
+
 
 class DynamicKafkaModel:
     """ class model for automatic serialization of Pandas DataFrame to

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -28,13 +28,9 @@ class KafkaProducer:
     def produce(self, item):
         while True:
             try:
-                print(item)
-                print(type(item))
-                key = self._key_object(item)
-
                 self._producer.produce(
                     topic=self._topic,
-                    key=key,
+                    key=item if self._key else None,
                     value=item,
                     on_delivery=self._delivery_report
                 )
@@ -42,19 +38,13 @@ class KafkaProducer:
                 break
             except BufferError as e:
                 print(
-                    f'Failed to send on attempt {key}. '
+                    f'Failed to send on attempt {item}. '
                     f'Error received {str(e)}')
                 self._producer.poll(1)
 
     def flush(self):
         if self._producer:
             self._producer.flush()
-
-    def _key_object(self, item):
-        if self._key:
-            return item.dict(include={self._key})
-        else:
-            return str(uuid4())
 
     @staticmethod
     def _delivery_report(err: KafkaError, msg: Message):

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -19,7 +19,7 @@ from confluent_kafka import SerializingProducer
 from confluent_kafka import KafkaError, Message
 
 
-class KafkaSerializer:
+class KafkaProducer:
     def __init__(self, topic, key, producer_config):
         self._topic = topic
         self._key = key

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -28,6 +28,8 @@ class KafkaProducer:
     def produce(self, item):
         while True:
             try:
+                print(item)
+                print(type(item))
                 key = self._key_object(item)
 
                 self._producer.produce(
@@ -50,7 +52,7 @@ class KafkaProducer:
 
     def _key_object(self, item):
         if self._key:
-            return {self._key: item.dict()[self._key]}
+            return item.dict(include={self._key})
         else:
             return str(uuid4())
 

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -17,10 +17,10 @@ from confluent_kafka import KafkaError, Message
 
 
 class KafkaProducer:
-    def __init__(self, topic, key, producer_config):
+    def __init__(self, topic, producer_config):
         self._topic = topic
-        self._key = key
-        self._producer = SerializingProducer(producer_config.get())
+        self._key = producer_config.key
+        self._producer = SerializingProducer(producer_config.dict)
 
     def produce(self, item):
         while True:

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from uuid import uuid4
-
 from confluent_kafka import SerializingProducer
 from confluent_kafka import KafkaError, Message
 

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -19,16 +19,18 @@ from confluent_kafka import KafkaError, Message
 class KafkaProducer:
     def __init__(self, topic, producer_config):
         self._topic = topic
-        self._key = producer_config.key
         self._producer = SerializingProducer(producer_config.dict)
+        self._serializer = producer_config.serializer
 
     def produce(self, item):
         while True:
             try:
+                key, value = self._serializer.serialize(item)
+
                 self._producer.produce(
                     topic=self._topic,
-                    key=item if self._key else None,
-                    value=item,
+                    key=key,
+                    value=value,
                     on_delivery=self._delivery_report
                 )
                 self._producer.poll(0)

--- a/py2k/producer_config.py
+++ b/py2k/producer_config.py
@@ -28,7 +28,12 @@ class ProducerConfig:
                                            key,
                                            schema_registry_config)
 
-    def get(self):
+    @property
+    def key(self):
+        return self._key
+
+    @property
+    def dict(self):
         if self._config_build:
             return self._config_build
 

--- a/py2k/producer_config.py
+++ b/py2k/producer_config.py
@@ -19,34 +19,28 @@ from py2k.serializer import KafkaSerializer
 
 
 class ProducerConfig:
-    def __init__(self, key, default_config, schema_registry_config, data):
+    def __init__(self, key, default_config, schema_registry_config, item):
         self._key = key
         self._default_config = default_config
         self._config_build = None
 
-        self._serializer = KafkaSerializer(data[0], key, schema_registry_config)
+        self._serializer = KafkaSerializer(item,
+                                           key,
+                                           schema_registry_config)
 
     def get(self):
         if self._config_build:
             return self._config_build
 
         config_build = deepcopy(self._default_config)
-        serializer_configs = {
-            **self._value_serializer_config, **self._key_serializer_config}
-        config_build.update(serializer_configs)
+        config_build['value.serializer'] = self._serializer.value_serializer()
+
+        if self._key:
+            config_build['key.serializer'] = self._serializer.key_serializer()
 
         self._config_build = config_build
         return self._config_build
 
-    @property
-    def _value_serializer_config(self):
-        return {'value.serializer': self._serializer.value_serializer()}
 
-    @property
-    def _key_serializer_config(self):
-        if not self._key:
-            return {}
-
-        return {'key.serializer': self._serializer.key_serializer()}
 
 

--- a/py2k/producer_config.py
+++ b/py2k/producer_config.py
@@ -40,7 +40,3 @@ class ProducerConfig:
 
         self._config_build = config_build
         return self._config_build
-
-
-
-

--- a/py2k/producer_config.py
+++ b/py2k/producer_config.py
@@ -15,22 +15,21 @@
 
 from copy import deepcopy
 
-from py2k.serializer import KafkaSerializer
-
 
 class ProducerConfig:
-    def __init__(self, key, default_config, schema_registry_config, item):
+    def __init__(self, key, default_config, serializer):
         self._key = key
         self._default_config = default_config
+        self._serializer = serializer
         self._config_build = None
-
-        self._serializer = KafkaSerializer(item,
-                                           key,
-                                           schema_registry_config)
 
     @property
     def key(self):
         return self._key
+
+    @property
+    def serializer(self):
+        return self._serializer
 
     @property
     def dict(self):
@@ -40,8 +39,9 @@ class ProducerConfig:
         config_build = deepcopy(self._default_config)
         config_build['value.serializer'] = self._serializer.value_serializer()
 
-        if self._key:
-            config_build['key.serializer'] = self._serializer.key_serializer()
+        key_serializer = self._serializer.key_serializer()
+        if key_serializer:
+            config_build['key.serializer'] = key_serializer
 
         self._config_build = config_build
         return self._config_build

--- a/py2k/producer_config.py
+++ b/py2k/producer_config.py
@@ -17,15 +17,10 @@ from copy import deepcopy
 
 
 class ProducerConfig:
-    def __init__(self, key, default_config, serializer):
-        self._key = key
+    def __init__(self, default_config, serializer):
         self._default_config = default_config
         self._serializer = serializer
         self._config_build = None
-
-    @property
-    def key(self):
-        return self._key
 
     @property
     def serializer(self):

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -1,0 +1,70 @@
+# Copyright 2021 ABSA Group Limited
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from typing import List, Dict, Any
+
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.avro import AvroSerializer
+
+from py2k.models import KafkaModel
+
+
+class KafkaSerializer:
+    def __init__(self, item: KafkaModel, key, schema_registry_config: dict):
+        self._item = item
+        self._key = key
+        self._schema_registry_client = SchemaRegistryClient(
+            schema_registry_config)
+
+    def value_serializer(self):
+        return AvroSerializer(
+            self._item.schema_json(),
+            self._schema_registry_client,
+            to_dict=self._to_dict_func()
+        )
+
+    def key_serializer(self):
+        if not self._key:
+            return None
+
+        return AvroSerializer(
+            schema_str=self._key_schema_string,
+            schema_registry_client=self._schema_registry_client,
+            to_dict=self._to_dict_func({self._key})
+        )
+
+    @property
+    def _key_schema_string(self):
+        key_schema = {}
+        _value_schema = json.loads(self._item.schema_json())
+        key_schema['type'] = _value_schema['type']
+        key_schema['name'] = f'{_value_schema["name"]}Key'
+        key_schema['namespace'] = _value_schema['namespace']
+        key_schema['fields'] = self._find_key_fields(_value_schema['fields'])
+        return str(key_schema).replace("'", "\"")
+
+    def _find_key_fields(self, fields: List[Dict[str, Any]]) -> Dict[str, Any]:
+        def is_key(field):
+            return any(v == self._key for _, v in field.items())
+
+        return [field for field in fields if is_key(field)]
+
+    @staticmethod
+    def _to_dict_func(include=None):
+        def to_dict(results: KafkaModel, _):
+            return json.loads(results.json(include=include))
+
+        return to_dict

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -45,9 +45,13 @@ class KafkaSerializer:
         )
 
     def serialize(self, item):
-        key = json.loads(item.json(include={self._key})) if self._key else None
-        value = json.loads(item.json())
+        key = self._serialize_item(item, {self._key}) if self._key else None
+        value = self._serialize_item(item)
         return key, value
+
+    @staticmethod
+    def _serialize_item(item, include=None):
+        return json.loads(item.json(include=include))
 
     @property
     def _key_schema_string(self):
@@ -64,10 +68,3 @@ class KafkaSerializer:
             return any(v == self._key for _, v in field.items())
 
         return [field for field in fields if is_key(field)]
-
-    @staticmethod
-    def _to_dict_func(include=None):
-        def to_dict(results: KafkaModel, _):
-            return json.loads(results.json(include=include))
-
-        return to_dict

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -32,8 +32,7 @@ class KafkaSerializer:
     def value_serializer(self):
         return AvroSerializer(
             self._item.schema_json(),
-            self._schema_registry_client,
-            to_dict=self._to_dict_func()
+            self._schema_registry_client
         )
 
     def key_serializer(self):
@@ -42,9 +41,13 @@ class KafkaSerializer:
 
         return AvroSerializer(
             schema_str=self._key_schema_string,
-            schema_registry_client=self._schema_registry_client,
-            to_dict=self._to_dict_func({self._key})
+            schema_registry_client=self._schema_registry_client
         )
+
+    def serialize(self, item):
+        key = json.loads(item.json(include={self._key})) if self._key else None
+        value = json.loads(item.json())
+        return key, value
 
     @property
     def _key_schema_string(self):

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 from py2k.models import KafkaModel
 from py2k.producer_config import ProducerConfig
 from py2k.producer import KafkaProducer
+from py2k.serializer import KafkaSerializer
 
 
 class KafkaWriter(object):
@@ -45,11 +46,13 @@ class KafkaWriter(object):
         self._producer = None
 
     def _create_producer(self, data: List[KafkaModel]):
+        serializer = KafkaSerializer(data[0], self._key,
+                                     self._schema_registry_config)
+
         producer_config = ProducerConfig(
             self._key,
             self._producer_config,
-            self._schema_registry_config,
-            data[0]
+            serializer
         )
 
         self._producer = KafkaProducer(self._topic, producer_config)

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 from py2k.models import KafkaModel
 from py2k.producer_config import ProducerConfig
-from py2k.serializer import KafkaSerializer
+from py2k.producer import KafkaProducer
 
 
 class KafkaWriter(object):
@@ -39,18 +39,20 @@ class KafkaWriter(object):
         """
 
         self._topic = topic
-        self._default_producer_config = producer_config
+        self._producer_config = producer_config
         self._key = key
         self._schema_registry_config = schema_registry_config
-        self._serializer = None
+        self._producer = None
 
-    def _create_serializer(self, data: List[KafkaModel]):
+    def _create_producer(self, data: List[KafkaModel]):
         producer_config = ProducerConfig(
             self._key,
-            self._default_producer_config,
-            self._schema_registry_config, data)
+            self._producer_config,
+            self._schema_registry_config,
+            data
+        )
 
-        self._serializer = KafkaSerializer(
+        self._producer = KafkaProducer(
             self._topic, self._key, producer_config)
 
     def write(self, data: List[KafkaModel]):
@@ -59,8 +61,8 @@ class KafkaWriter(object):
         Args:
             data (List[KafkaModel]): Serialized `KafkaModel` objects
         """
-        self._create_serializer(data)
+        self._create_producer(data)
         for item in tqdm(data):
-            self._serializer.produce(item)
+            self._producer.produce(item)
 
-        self._serializer.flush()
+        self._producer.flush()

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -49,7 +49,7 @@ class KafkaWriter(object):
             self._key,
             self._producer_config,
             self._schema_registry_config,
-            data
+            data[0]
         )
 
         self._producer = KafkaProducer(

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -49,11 +49,7 @@ class KafkaWriter(object):
         serializer = KafkaSerializer(data[0], self._key,
                                      self._schema_registry_config)
 
-        producer_config = ProducerConfig(
-            self._key,
-            self._producer_config,
-            serializer
-        )
+        producer_config = ProducerConfig(self._producer_config, serializer)
 
         self._producer = KafkaProducer(self._topic, producer_config)
 

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -52,8 +52,7 @@ class KafkaWriter(object):
             data[0]
         )
 
-        self._producer = KafkaProducer(
-            self._topic, self._key, producer_config)
+        self._producer = KafkaProducer(self._topic, producer_config)
 
     def write(self, data: List[KafkaModel]):
         """writes data to Kafka

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -27,7 +27,48 @@ from py2k.writer import KafkaWriter
 
 
 @pytest.fixture
-def data_class():
+def raw_input():
+    return [
+        {'Customerkey': 'Adam',
+         'Predictedvalue': 123.22,
+         'Timesince': 4,
+         'Applicableto': '2020-07',
+         'Generationdate': datetime.date(2020, 3, 20)},
+        {'Customerkey': 'Andy',
+         'Predictedvalue': 12545.0,
+         'Timesince': 4,
+         'Applicableto': '2020-09',
+         'Generationdate': datetime.date(2020, 8, 2)},
+        {'Customerkey': 'Daniel',
+         'Predictedvalue': 123,
+         'Timesince': 4,
+         'Applicableto': '2020-03',
+         'Generationdate': datetime.date(2020, 12, 9)},
+        {'Customerkey': 'Dennis',
+         'Predictedvalue': 44123.02,
+         'Timesince': 4,
+         'Applicableto': '2020-10',
+         'Generationdate': datetime.date(2020, 4, 21)},
+        {'Customerkey': 'Felipe',
+         'Predictedvalue': 11111,
+         'Timesince': 4,
+         'Applicableto': '2020-01',
+         'Generationdate': datetime.date(2020, 8, 17)},
+    ]
+
+
+@pytest.fixture
+def serialized_first_input():
+    return {
+        'Customerkey': 'Adam',
+        'Predictedvalue': 123.22,
+        'Timesince': 4,
+        'Applicableto': '2020-07',
+        'Generationdate': '2020-03-20'
+    }
+
+@pytest.fixture
+def data_class(raw_input):
     class ModelResult(KafkaModel):
         Customerkey: str
         Predictedvalue: float
@@ -35,67 +76,13 @@ def data_class():
         Applicableto: str
         Generationdate: datetime.date
 
-    result = [
-        {'Customerkey': 'Adam',
-         'Predictedvalue': 123.22,
-         'Timesince': 4,
-         'Applicableto': '2020-07',
-         'Generationdate': datetime.date(2020, 3, 20)},
-        {'Customerkey': 'Andy',
-         'Predictedvalue': 12545.0,
-         'Timesince': 4,
-         'Applicableto': '2020-09',
-         'Generationdate': datetime.date(2020, 8, 2)},
-        {'Customerkey': 'Daniel',
-         'Predictedvalue': 123,
-         'Timesince': 4,
-         'Applicableto': '2020-03',
-         'Generationdate': datetime.date(2020, 12, 9)},
-        {'Customerkey': 'Dennis',
-         'Predictedvalue': 44123.02,
-         'Timesince': 4,
-         'Applicableto': '2020-10',
-         'Generationdate': datetime.date(2020, 4, 21)},
-        {'Customerkey': 'Felipe',
-         'Predictedvalue': 11111,
-         'Timesince': 4,
-         'Applicableto': '2020-01',
-         'Generationdate': datetime.date(2020, 8, 17)},
-    ]
-    output = [ModelResult(**value) for value in result]
+    output = [ModelResult(**value) for value in raw_input]
     return output
 
 
 @pytest.fixture
-def pandas_dataframe():
-    result = [
-        {'Customerkey': 'Adam',
-         'Predictedvalue': 123.22,
-         'Timesince': 4,
-         'Applicableto': '2020-07',
-         'Generationdate': datetime.date(2020, 3, 20)},
-        {'Customerkey': 'Andy',
-         'Predictedvalue': 12545.0,
-         'Timesince': 4,
-         'Applicableto': '2020-09',
-         'Generationdate': datetime.date(2020, 8, 2)},
-        {'Customerkey': 'Daniel',
-         'Predictedvalue': 123,
-         'Timesince': 4,
-         'Applicableto': '2020-03',
-         'Generationdate': datetime.date(2020, 12, 9)},
-        {'Customerkey': 'Dennis',
-         'Predictedvalue': 44123.02,
-         'Timesince': 4,
-         'Applicableto': '2020-10',
-         'Generationdate': datetime.date(2020, 4, 21)},
-        {'Customerkey': 'Felipe',
-         'Predictedvalue': 11111,
-         'Timesince': 4,
-         'Applicableto': '2020-01',
-         'Generationdate': datetime.date(2020, 8, 17)},
-    ]
-    return pd.DataFrame(result)
+def pandas_dataframe(raw_input):
+    return pd.DataFrame(raw_input)
 
 
 def test_kafka_model(data_class):
@@ -131,11 +118,12 @@ def test_pandas_serializer(pandas_dataframe, data_class):
     assert actual == expected
 
 
-def test_pushes_one_item_of_model_data(monkeypatch, data_class):
+def test_pushes_one_item_of_model_data(monkeypatch, data_class,
+                                       serialized_first_input):
     topic = "DUMMY_TOPIC"
     key = "Customerkey"
-    one_item = data_class[0]
-    one_item_list = [one_item]
+
+    one_item_list = data_class[:1]
 
     producer_class = MagicMock()
     producer = MagicMock()
@@ -148,15 +136,18 @@ def test_pushes_one_item_of_model_data(monkeypatch, data_class):
     writer = KafkaWriter(topic, {}, {}, key)
     writer.write(one_item_list)
 
+    expected_key = {key: serialized_first_input[key]}
+
     producer.produce.assert_called_with(
-        topic=topic, key=one_item, value=one_item, on_delivery=ANY)
+        topic=topic, key=expected_key, value=serialized_first_input,
+        on_delivery=ANY)
     producer.poll.assert_called_with(0)
 
 
-def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class):
+def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class,
+                                                   serialized_first_input):
     topic = "DUMMY_TOPIC"
-    one_item = data_class[0]
-    one_item_list = [one_item]
+    one_item_list = data_class[:1]
 
     producer_class = MagicMock()
     producer = MagicMock()
@@ -170,5 +161,5 @@ def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class):
     writer.write(one_item_list)
 
     producer.produce.assert_called_with(
-        topic=topic, key=None, value=one_item, on_delivery=ANY)
+        topic=topic, key=None, value=serialized_first_input, on_delivery=ANY)
     producer.poll.assert_called_with(0)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 
 import py2k.producer_config
-import py2k.serializer
+import py2k.producer
 from py2k.models import KafkaModel
 from py2k.writer import KafkaWriter
 
@@ -140,7 +140,7 @@ def test_pushes_one_item_of_model_data(monkeypatch, data_class):
     producer = MagicMock()
     producer_class.return_value = producer
 
-    monkeypatch.setattr(py2k.serializer, 'SerializingProducer', producer_class)
+    monkeypatch.setattr(py2k.producer, 'SerializingProducer', producer_class)
     monkeypatch.setattr(py2k.producer_config,
                         'SchemaRegistryClient', MagicMock())
 
@@ -163,7 +163,7 @@ def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class):
     producer = MagicMock()
     producer_class.return_value = producer
 
-    monkeypatch.setattr(py2k.serializer, 'SerializingProducer', producer_class)
+    monkeypatch.setattr(py2k.producer, 'SerializingProducer', producer_class)
     monkeypatch.setattr(py2k.producer_config,
                         'SchemaRegistryClient', MagicMock())
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -21,6 +21,7 @@ import pytest
 
 import py2k.producer_config
 import py2k.producer
+import py2k.serializer
 from py2k.models import KafkaModel
 from py2k.writer import KafkaWriter
 
@@ -141,16 +142,14 @@ def test_pushes_one_item_of_model_data(monkeypatch, data_class):
     producer_class.return_value = producer
 
     monkeypatch.setattr(py2k.producer, 'SerializingProducer', producer_class)
-    monkeypatch.setattr(py2k.producer_config,
+    monkeypatch.setattr(py2k.serializer,
                         'SchemaRegistryClient', MagicMock())
 
     writer = KafkaWriter(topic, {}, {}, key)
     writer.write(one_item_list)
 
-    expected_key = {key: getattr(one_item, key)}
-
     producer.produce.assert_called_with(
-        topic=topic, key=expected_key, value=one_item, on_delivery=ANY)
+        topic=topic, key=one_item, value=one_item, on_delivery=ANY)
     producer.poll.assert_called_with(0)
 
 
@@ -164,12 +163,12 @@ def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class):
     producer_class.return_value = producer
 
     monkeypatch.setattr(py2k.producer, 'SerializingProducer', producer_class)
-    monkeypatch.setattr(py2k.producer_config,
+    monkeypatch.setattr(py2k.serializer,
                         'SchemaRegistryClient', MagicMock())
 
     writer = KafkaWriter(topic, {}, {})
     writer.write(one_item_list)
 
     producer.produce.assert_called_with(
-        topic=topic, key=ANY, value=one_item, on_delivery=ANY)
+        topic=topic, key=None, value=one_item, on_delivery=ANY)
     producer.poll.assert_called_with(0)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -39,21 +39,6 @@ def raw_input():
          'Timesince': 4,
          'Applicableto': '2020-09',
          'Generationdate': datetime.date(2020, 8, 2)},
-        {'Customerkey': 'Daniel',
-         'Predictedvalue': 123,
-         'Timesince': 4,
-         'Applicableto': '2020-03',
-         'Generationdate': datetime.date(2020, 12, 9)},
-        {'Customerkey': 'Dennis',
-         'Predictedvalue': 44123.02,
-         'Timesince': 4,
-         'Applicableto': '2020-10',
-         'Generationdate': datetime.date(2020, 4, 21)},
-        {'Customerkey': 'Felipe',
-         'Predictedvalue': 11111,
-         'Timesince': 4,
-         'Applicableto': '2020-01',
-         'Generationdate': datetime.date(2020, 8, 17)},
     ]
 
 
@@ -66,6 +51,7 @@ def serialized_first_input():
         'Applicableto': '2020-07',
         'Generationdate': '2020-03-20'
     }
+
 
 @pytest.fixture
 def data_class(raw_input):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

This PR is focused on refactoring and  KafkaWriter and separation of responsibilities. Concretely:

- Better naming to avoid confusion: KafkaSerializer -> KafkaProducer
- Simplifying of KafkaProducer be moving serialization to KafkaSerialization
- Stop creating artifitial key, when no key is provided

## Related issue number

#31 #20 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI and coverage remains at 100%
- [x] Documentation reflects the changes where applicable
- [x] Version bumped if necessary
- [ ] Changes are documented in [HISTORY.md](../HISTORY.md)
