### PR TITLE
Parlance and Schema Move

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,21 @@
 # History
 
+## 1.8.0 (2021-03-29)
+
+- Adhering to Kafka and Avro parlance by renaming:
+  - models module -> record
+  - KafkaModel -> KafkaRecord
+  - DynamicPandasModel -> PandasToRecordsTransformer
+  - item -> record
+- Move schema knowledge to KafkaRecord
+- Introduce `__key_fields__` in KafkaRecord to enable specifying which fields are part of the key
+- Introduce `__include_key__` in KafkaRecord to enable specifying whether key_fields should be part of the value message
+
+Big thank you to @vesely-david for this change
+
 ## 1.7.0 (2021-03-11)
 
- - Minor API change for easier dynamic creation of KafkaModels from a pandas DataFrame
+- Minor API change for easier dynamic creation of KafkaModels from a pandas DataFrame
 
 ## 1.6.0 (2021-03-01)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please see the [Contribution Guide](.github/CONTRIBUTING.md) for more informatio
 ### Minimal Example
 
 ```python
-from py2k.models import PandasToRecordsTransformer
+from py2k.record import PandasToRecordsTransformer
 from py2k.writer import KafkaWriter
 
 # assuming we have a pandas DataFrame, df

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Please see the [Contribution Guide](.github/CONTRIBUTING.md) for more informatio
 ### Minimal Example
 
 ```python
-from py2k.models import PandasToKafkaTransformer
+from py2k.models import PandasToRecordsTransformer
 from py2k.writer import KafkaWriter
 
 # assuming we have a pandas DataFrame, df
-records = PandasToKafkaTransformer(df=df, record_name='test_model').from_pandas()
+records = PandasToRecordsTransformer(df=df, record_name='test_model').from_pandas()
 
 writer = KafkaWriter(
     topic="topic_name",

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Please see the [Contribution Guide](.github/CONTRIBUTING.md) for more informatio
 ### Minimal Example
 
 ```python
-from py2k.models import DynamicKafkaModel
+from py2k.models import PandasToKafkaTransformer
 from py2k.writer import KafkaWriter
 
 # assuming we have a pandas DataFrame, df
-serialized_df = DynamicKafkaModel(df=df,model_name='test_model').from_pandas()
+records = PandasToKafkaTransformer(df=df, record_name='test_model').from_pandas()
 
 writer = KafkaWriter(
     topic="topic_name",
@@ -33,7 +33,7 @@ writer = KafkaWriter(
     producer_config=producer_config
 )
 
-writer.write(serialized_df)
+writer.write(records)
 ```
 
 ## Features

--- a/py2k/models.py
+++ b/py2k/models.py
@@ -82,7 +82,8 @@ class KafkaModel(BaseModel):
         return list(itertools.islice(iterator, 1))[0].schema_json()
 
     def value_to_avro_dict(self):
-        return json.loads(self.json())
+        key_fields = set(self.key_fields) if self.key_fields else {}
+        return json.loads(self.json(exclude=key_fields))
 
     def key_to_avro_dict(self):
         if not self.key_fields:

--- a/py2k/models.py
+++ b/py2k/models.py
@@ -34,6 +34,7 @@ class IterableAdapter:
 
 
 class KafkaModel(BaseModel):
+    __key_fields__ = None
 
     @classmethod
     def from_pandas(cls, df: pd.DataFrame) -> List['KafkaModel']:
@@ -78,6 +79,10 @@ class KafkaModel(BaseModel):
     @staticmethod
     def schema_from_iter(iterator: IterableAdapter):
         return list(itertools.islice(iterator, 1))[0].schema_json()
+
+    @property
+    def key_fields(self):
+        return self.__key_fields__
 
 
 class DynamicKafkaModel:

--- a/py2k/models.py
+++ b/py2k/models.py
@@ -37,7 +37,7 @@ class IterableAdapter:
 
 class KafkaRecord(BaseModel):
     __key_fields__: set = {}
-    __key_included__: bool = False
+    __include_key__: bool = False
 
     @classmethod
     def from_pandas(cls, df: pd.DataFrame) -> List['KafkaRecord']:
@@ -99,7 +99,7 @@ class KafkaRecord(BaseModel):
 
     @property
     def key_included(self):
-        return self.__key_included__
+        return self.__include_key__
 
     @property
     def value_fields(self):
@@ -135,7 +135,7 @@ class KafkaRecord(BaseModel):
         return str(dictionary).replace("'", "\"")
 
 
-class PandasToKafkaTransformer:
+class PandasToRecordsTransformer:
     """ class model for automatic serialization of Pandas DataFrame to
     KafkaModel
     """
@@ -145,7 +145,7 @@ class PandasToKafkaTransformer:
                  types_defaults: Dict[object, object] = None,
                  optional_fields: List[str] = None,
                  key_fields: Set[str] = None,
-                 key_included: bool = None):
+                 include_key: bool = None):
         """
         Args:
             df (pd.DataFrame): Pandas dataframe to serialize
@@ -160,12 +160,12 @@ class PandasToKafkaTransformer:
                  be marked as optional. Defaults to None.
             key_fields (Set[str], optional): set of fields which are meant
                 to be key of the schema
-            key_included: bool: Indicator whether key fields should be
+            include_key: bool: Indicator whether key fields should be
                 included in value
         """
 
         self._df = df
-        _class = self._class(key_fields, key_included)
+        _class = self._class(key_fields, include_key)
 
         model_creator = PandasModelCreator(df, record_name, fields_defaults,
                                            types_defaults, optional_fields,
@@ -191,7 +191,7 @@ class PandasToKafkaTransformer:
     def _class(key_fields, key_included):
         if key_included and key_fields:
             class WithIncluded(KafkaRecord):
-                __key_included__ = key_included
+                __include_key__ = key_included
                 __key_fields__ = key_fields
 
             return WithIncluded

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -20,24 +20,21 @@ class KafkaProducer:
     def __init__(self, topic, producer_config):
         self._topic = topic
         self._producer = SerializingProducer(producer_config.dict)
-        self._serializer = producer_config.serializer
 
-    def produce(self, item):
+    def produce(self, record):
         while True:
             try:
-                key, value = self._serializer.serialize(item)
-
                 self._producer.produce(
                     topic=self._topic,
-                    key=key,
-                    value=value,
+                    key=record.key_to_avro_dict(),
+                    value=record.value_to_avro_dict(),
                     on_delivery=self._delivery_report
                 )
                 self._producer.poll(0)
                 break
             except BufferError as e:
                 print(
-                    f'Failed to send on attempt {item}. '
+                    f'Failed to send on attempt {record}. '
                     f'Error received {str(e)}')
                 self._producer.poll(1)
 

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -31,8 +31,8 @@ class KafkaSerializer:
 
     def value_serializer(self):
         return AvroSerializer(
-            self._record.schema_json(),
-            self._schema_registry_client,
+            schema_str=self._record.schema_json(),
+            schema_registry_client=self._schema_registry_client,
         )
 
     def key_serializer(self):
@@ -56,6 +56,6 @@ class KafkaSerializer:
 
     def _find_key_fields(self, fields: List[Dict[str, Any]]) -> Dict[str, Any]:
         def is_key(field):
-            return any(v == self._key_fields for _, v in field.items())
+            return field.get('name') in self._key_fields
 
         return [field for field in fields if is_key(field)]

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -16,11 +16,11 @@
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.avro import AvroSerializer
 
-from py2k.models import KafkaModel
+from py2k.models import KafkaRecord
 
 
 class KafkaSerializer:
-    def __init__(self, record: KafkaModel, schema_registry_config: dict):
+    def __init__(self, record: KafkaRecord, schema_registry_config: dict):
         self._record = record
         self._key_fields = record.key_fields
         self._key_included = record.key_included

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -26,6 +26,7 @@ class KafkaSerializer:
     def __init__(self, record: KafkaModel, schema_registry_config: dict):
         self._record = record
         self._key_fields = record.key_fields
+        self._key_included = record.key_included
         self._schema_registry_client = SchemaRegistryClient(
             schema_registry_config)
 
@@ -47,7 +48,7 @@ class KafkaSerializer:
     @property
     def _value_schema_string(self):
         _value_schema = json.loads(self._record.schema_json())
-        if self._key_fields:
+        if self._key_fields and not self._key_included:
             fields = _value_schema['fields']
             _value_schema['fields'] = self._find_val_fields(fields)
 

--- a/py2k/serializer.py
+++ b/py2k/serializer.py
@@ -16,14 +16,14 @@
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.avro import AvroSerializer
 
-from py2k.models import KafkaRecord
+from py2k.record import KafkaRecord
 
 
 class KafkaSerializer:
     def __init__(self, record: KafkaRecord, schema_registry_config: dict):
         self._record = record
         self._key_fields = record.key_fields
-        self._key_included = record.key_included
+        self._key_included = record.include_key
         self._schema_registry_client = SchemaRegistryClient(
             schema_registry_config)
 

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 
 from tqdm import tqdm
 
-from py2k.models import KafkaRecord
+from py2k.record import KafkaRecord
 from py2k.producer_config import ProducerConfig
 from py2k.producer import KafkaProducer
 from py2k.serializer import KafkaSerializer

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List
 
 from tqdm import tqdm
 
-from py2k.models import KafkaModel
+from py2k.models import KafkaRecord
 from py2k.producer_config import ProducerConfig
 from py2k.producer import KafkaProducer
 from py2k.serializer import KafkaSerializer
@@ -42,17 +42,17 @@ class KafkaWriter(object):
         self._schema_registry_config = schema_registry_config
         self._producer = None
 
-    def _create_producer(self, data: List[KafkaModel]):
+    def _create_producer(self, data: List[KafkaRecord]):
         serializer = KafkaSerializer(data[0], self._schema_registry_config)
         producer_config = ProducerConfig(self._producer_config, serializer)
 
         self._producer = KafkaProducer(self._topic, producer_config)
 
-    def write(self, records: List[KafkaModel]):
+    def write(self, records: List[KafkaRecord]):
         """writes data to Kafka
 
         Args:
-            records (List[KafkaModel]): Serialized `KafkaModel` objects
+            records (List[KafkaRecord]): Serialized `KafkaModel` objects
         """
         self._create_producer(records)
         for record in tqdm(records):

--- a/py2k/writer.py
+++ b/py2k/writer.py
@@ -26,8 +26,7 @@ class KafkaWriter(object):
     def __init__(self,
                  topic: str,
                  schema_registry_config: Dict[str, Any],
-                 producer_config: Dict[str, Any],
-                 key: str = None):
+                 producer_config: Dict[str, Any]):
         """A class for easy writing of data to kafka
 
         Args:
@@ -36,31 +35,27 @@ class KafkaWriter(object):
                 with the `confluent_kafka.schema_registry.SchemaRegistryClient`
             producer_config (Dict[str, Any]): a dictionary compatible with the
                 `confluent_kafka.SerializingProducer`
-            key (str, optional): [description]. Defaults to None.
         """
 
         self._topic = topic
         self._producer_config = producer_config
-        self._key = key
         self._schema_registry_config = schema_registry_config
         self._producer = None
 
     def _create_producer(self, data: List[KafkaModel]):
-        serializer = KafkaSerializer(data[0], self._key,
-                                     self._schema_registry_config)
-
+        serializer = KafkaSerializer(data[0], self._schema_registry_config)
         producer_config = ProducerConfig(self._producer_config, serializer)
 
         self._producer = KafkaProducer(self._topic, producer_config)
 
-    def write(self, data: List[KafkaModel]):
+    def write(self, records: List[KafkaModel]):
         """writes data to Kafka
 
         Args:
-            data (List[KafkaModel]): Serialized `KafkaModel` objects
+            records (List[KafkaModel]): Serialized `KafkaModel` objects
         """
-        self._create_producer(data)
-        for item in tqdm(data):
-            self._producer.produce(item)
+        self._create_producer(records)
+        for record in tqdm(records):
+            self._producer.produce(record)
 
         self._producer.flush()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/AbsaOSS/py2k.git',
-    version='1.7.0',
+    version='1.8.0',
     zip_safe=False,
 )

--- a/tests/test_creators.py
+++ b/tests/test_creators.py
@@ -19,7 +19,7 @@ import pandas as pd
 import pytest
 
 from py2k.creators import PandasModelCreator
-from py2k.models import KafkaRecord
+from py2k.record import KafkaRecord
 
 
 @pytest.mark.parametrize(

--- a/tests/test_creators.py
+++ b/tests/test_creators.py
@@ -19,7 +19,7 @@ import pandas as pd
 import pytest
 
 from py2k.creators import PandasModelCreator
-from py2k.models import KafkaModel
+from py2k.models import KafkaRecord
 
 
 @pytest.mark.parametrize(
@@ -37,7 +37,7 @@ from py2k.models import KafkaModel
 def test_creates_model_with_field_of_type(expected_type, value):
     df = pd.DataFrame({'field_name': [value]})
 
-    model = PandasModelCreator(df, 'TestModel', base=KafkaModel).create()
+    model = PandasModelCreator(df, 'TestModel', base=KafkaRecord).create()
     fields = model.__fields__
     field = list(fields.values())[0]
 
@@ -49,4 +49,4 @@ def test_creates_model_with_field_of_type(expected_type, value):
 def test_throw_exception_when_creating_model_from_empty_df():
     with pytest.raises(ValueError):
         empty_df = pd.DataFrame(data=[], columns=['c1', 'c2', 'c3'])
-        PandasModelCreator(empty_df, 'TestModel', base=KafkaModel).create()
+        PandasModelCreator(empty_df, 'TestModel', base=KafkaRecord).create()

--- a/tests/test_dynamic_model.py
+++ b/tests/test_dynamic_model.py
@@ -204,9 +204,9 @@ def test_supported_optional_types(value, _type):
 def test_specification_of_key_fields():
     df = pd.DataFrame({'column_1': [1], 'key': ['key_val']})
 
-    model = PandasToKafkaTransformer(df, 'TestModel', key_fields=['key'])
+    model = PandasToKafkaTransformer(df, 'TestModel', key_fields={'key'})
     record = model.from_pandas(df)[0]
-    assert record.key_fields == ['key']
+    assert record.key_fields == {'key'}
 
 
 def _assert_records(records, test_data):

--- a/tests/test_dynamic_model.py
+++ b/tests/test_dynamic_model.py
@@ -23,7 +23,7 @@ import pytest
 from pydantic import BaseModel
 
 from py2k.creators import PandasModelCreator
-from py2k.models import DynamicKafkaModel, KafkaModel
+from py2k.models import PandasToKafkaTransformer, KafkaRecord
 
 
 class _TestData(BaseModel):
@@ -65,7 +65,7 @@ def test_return_empty_if_df_empty(test_df):
     with pytest.warns(UserWarning) as record:
         empty_df = test_df.head(0)
 
-        model = DynamicKafkaModel(test_df, 'TestModel')
+        model = PandasToKafkaTransformer(test_df, 'TestModel')
         created_df = model.from_pandas(empty_df)
         assert len(created_df) == 0
 
@@ -75,19 +75,19 @@ def test_return_empty_if_df_empty(test_df):
 
 
 def test_dynamically_convert_from_pandas(test_data, test_df):
-    model = DynamicKafkaModel(test_df, 'TestModel')
+    model = PandasToKafkaTransformer(test_df, 'TestModel')
     records = model.from_pandas(test_df)
     _assert_records(records, test_data)
 
 
 def test_convert_from_constructed_dataframe_by_default(test_data, test_df):
-    model = DynamicKafkaModel(test_df, 'TestModel')
+    model = PandasToKafkaTransformer(test_df, 'TestModel')
     records = model.from_pandas()
     _assert_records(records, test_data)
 
 
 def test_fields_names_and_titles_are_the_same(test_df):
-    model = DynamicKafkaModel(test_df, 'TestModel')
+    model = PandasToKafkaTransformer(test_df, 'TestModel')
     records = model.from_pandas(test_df)
 
     for name, definition in records[0].__fields__.items():
@@ -95,7 +95,7 @@ def test_fields_names_and_titles_are_the_same(test_df):
 
 
 def test_use_default_defaults_if_none_informed(test_df):
-    model = DynamicKafkaModel(test_df, 'TestModel')
+    model = PandasToKafkaTransformer(test_df, 'TestModel')
     records = model.from_pandas(test_df)
 
     # expected defaults by field
@@ -110,7 +110,8 @@ def test_all_defaults_from_field_name(test_df):
     expected = {"name": "default name", "id": 8,
                 "value": 8.8, "decimal_val": 8.8, "bool_val": True}
 
-    model = DynamicKafkaModel(test_df, 'TestModel', fields_defaults=expected)
+    model = PandasToKafkaTransformer(test_df, 'TestModel',
+                                     fields_defaults=expected)
     records = model.from_pandas(test_df)
 
     _assert_schema_defaults(records[0], expected)
@@ -120,8 +121,8 @@ def test_some_defaults_from_field_name(test_df):
     local_defaults = {"name": "default name", "value": 8.8,
                       "decimal_val": Decimal(12), "bool_val": True}
 
-    model = DynamicKafkaModel(test_df, 'TestModel',
-                              fields_defaults=local_defaults)
+    model = PandasToKafkaTransformer(test_df, 'TestModel',
+                                     fields_defaults=local_defaults)
     records = model.from_pandas(test_df)
 
     expected = {**local_defaults,
@@ -133,7 +134,8 @@ def test_some_defaults_from_field_name(test_df):
 def test_all_defaults_from_field_type(test_df):
     expected = {str: "default name", int: 8, float: 8.8, bool: True}
 
-    model = DynamicKafkaModel(test_df, 'TestModel', types_defaults=expected)
+    model = PandasToKafkaTransformer(test_df, 'TestModel',
+                                     types_defaults=expected)
     records = model.from_pandas(test_df)
 
     _assert_schema_defaults(records[0], expected, by_name=False)
@@ -142,8 +144,8 @@ def test_all_defaults_from_field_type(test_df):
 def test_some_defaults_from_field_type(test_df):
     local_defaults = {int: 8, float: 8.8, bool: True}
 
-    model = DynamicKafkaModel(test_df, 'TestModel',
-                              types_defaults=local_defaults)
+    model = PandasToKafkaTransformer(test_df, 'TestModel',
+                                     types_defaults=local_defaults)
     records = model.from_pandas(test_df)
 
     expected = {**local_defaults,
@@ -153,8 +155,8 @@ def test_some_defaults_from_field_type(test_df):
 
 
 def test_optional_fields_specified_by_param(test_df_with_nones):
-    model = DynamicKafkaModel(test_df_with_nones, 'TestModel',
-                              optional_fields=['name'])
+    model = PandasToKafkaTransformer(test_df_with_nones, 'TestModel',
+                                     optional_fields=['name'])
     records = model.from_pandas(test_df_with_nones)
 
     expected = {"name": Optional[str], "id": int}
@@ -178,7 +180,7 @@ _optional_types_test_cases = [(value, Optional[_type])
 def test_supported_types(value, _type):
     df = pd.DataFrame({'column_1': [value]})
 
-    model = DynamicKafkaModel(df, 'TestModel')
+    model = PandasToKafkaTransformer(df, 'TestModel')
     records = model.from_pandas(df)
 
     expected = {'column_1': _type}
@@ -190,7 +192,8 @@ def test_supported_types(value, _type):
 def test_supported_optional_types(value, _type):
     df = pd.DataFrame({'column_1': [value]})
 
-    model = DynamicKafkaModel(df, 'TestModel', optional_fields=['column_1'])
+    model = PandasToKafkaTransformer(df, 'TestModel',
+                                     optional_fields=['column_1'])
     records = model.from_pandas(df)
 
     expected = {'column_1': _type}
@@ -201,7 +204,7 @@ def test_supported_optional_types(value, _type):
 def test_specification_of_key_fields():
     df = pd.DataFrame({'column_1': [1], 'key': ['key_val']})
 
-    model = DynamicKafkaModel(df, 'TestModel', key_fields=['key'])
+    model = PandasToKafkaTransformer(df, 'TestModel', key_fields=['key'])
     record = model.from_pandas(df)[0]
     assert record.key_fields == ['key']
 
@@ -213,7 +216,7 @@ def _assert_records(records, test_data):
     reconstructions = []
     for record in records:
         # makes sure the extracted models are instances of KafkaModel
-        assert issubclass(record.__class__, KafkaModel)
+        assert issubclass(record.__class__, KafkaRecord)
 
         reconstructions.append(_TestData(**record.dict()))
 

--- a/tests/test_dynamic_model.py
+++ b/tests/test_dynamic_model.py
@@ -198,6 +198,14 @@ def test_supported_optional_types(value, _type):
     _assert_schema_types(records[0], expected)
 
 
+def test_specification_of_key_fields():
+    df = pd.DataFrame({'column_1': [1], 'key': ['key_val']})
+
+    model = DynamicKafkaModel(df, 'TestModel', key_fields=['key'])
+    record = model.from_pandas(df)[0]
+    assert record.key_fields == ['key']
+
+
 def _assert_records(records, test_data):
     # makes sure all records were converted
     assert len(records) == len(test_data)

--- a/tests/test_dynamic_model.py
+++ b/tests/test_dynamic_model.py
@@ -23,7 +23,7 @@ import pytest
 from pydantic import BaseModel
 
 from py2k.creators import PandasModelCreator
-from py2k.models import PandasToRecordsTransformer, KafkaRecord
+from py2k.record import PandasToRecordsTransformer, KafkaRecord
 
 
 class _TestData(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,6 +45,33 @@ def test_dynamic_model_creates_creator_from_dataframe(model_creator_class):
     assert_frame_equal(df, called_df)
 
 
+def test_user_defines_model_without_key():
+    class MyRecord(KafkaModel):
+        value_1: str
+        value_2: int
+
+    df = pd.DataFrame({
+        'value_1': ['a', 'b'],
+        'value_2': [1, 2]
+    })
+    record = MyRecord.from_pandas(df)[0]
+    assert record.key_fields is None
+
+
+def test_user_defines_model_with_one_key():
+    class MyRecord(KafkaModel):
+        value_1: str
+        key_field: str
+        __key_fields__ = ['key_field']
+
+    df = pd.DataFrame({
+        'value_1': ['a', 'b'],
+        'key_field': [1, 2]
+    })
+    record = MyRecord.from_pandas(df)[0]
+    assert record.key_fields == ['key_field']
+
+
 @pytest.fixture
 def model_creator():
     return MagicMock()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ from pandas._testing import assert_frame_equal
 import pytest
 
 import py2k.models
-from py2k.models import KafkaRecord, PandasToKafkaTransformer
+from py2k.models import KafkaRecord, PandasToRecordsTransformer
 
 
 def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
@@ -28,7 +28,7 @@ def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
     optional_fields = ['field4']
 
     params = ANY, model_name, fields_defaults, types_defaults, optional_fields
-    PandasToKafkaTransformer(*params)
+    PandasToRecordsTransformer(*params)
 
     params_to_call = *params, KafkaRecord
     model_creator_class.assert_called_with(*params_to_call)
@@ -38,7 +38,7 @@ def test_dynamic_model_creates_creator_from_dataframe(model_creator_class):
     df = pd.DataFrame({'a': [1, 2], 'b': ["bla", "alb"]})
 
     params = df, ANY, ANY, ANY, ANY
-    PandasToKafkaTransformer(*params)
+    PandasToRecordsTransformer(*params)
 
     params_to_call = *params, KafkaRecord
     called_df, *_ = called_args(model_creator_class, len(params_to_call))
@@ -69,23 +69,23 @@ def test_user_defines_model_with_one_key(pandas_data):
 
 
 def test_dynamic_defines_key_fields(pandas_data):
-    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields={'key_field'})
+    model = PandasToRecordsTransformer(pandas_data, "MyRecord",
+                                       key_fields={'key_field'})
     record = model.from_pandas(pandas_data)[0]
     assert record.key_fields == {'key_field'}
 
 
 def test_dynamic_defines_key_included(pandas_data):
-    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields={'key_field'},
-                                     key_included=True)
+    model = PandasToRecordsTransformer(pandas_data, "MyRecord",
+                                       key_fields={'key_field'},
+                                       include_key=True)
     record = model.from_pandas(pandas_data)[0]
     assert record.key_included
 
 
 def test_dynamic_key_included_false_as_default(pandas_data):
-    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields={'key_field'})
+    model = PandasToRecordsTransformer(pandas_data, "MyRecord",
+                                       key_fields={'key_field'})
     record = model.from_pandas(pandas_data)[0]
     assert not record.key_included
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,29 +55,29 @@ def test_user_defines_model_without_key():
         'value_2': [1, 2]
     })
     record = MyRecord.from_pandas(df)[0]
-    assert record.key_fields is None
+    assert record.key_fields == {}
 
 
 def test_user_defines_model_with_one_key(pandas_data):
     class MyRecord(KafkaRecord):
         value_1: str
         key_field: str
-        __key_fields__ = ['key_field']
+        __key_fields__ = {'key_field'}
 
     record = MyRecord.from_pandas(pandas_data)[0]
-    assert record.key_fields == ['key_field']
+    assert record.key_fields == {'key_field'}
 
 
 def test_dynamic_defines_key_fields(pandas_data):
     model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields=['key_field'])
+                                     key_fields={'key_field'})
     record = model.from_pandas(pandas_data)[0]
-    assert record.key_fields == ['key_field']
+    assert record.key_fields == {'key_field'}
 
 
 def test_dynamic_defines_key_included(pandas_data):
     model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields=['key_field'],
+                                     key_fields={'key_field'},
                                      key_included=True)
     record = model.from_pandas(pandas_data)[0]
     assert record.key_included
@@ -85,7 +85,7 @@ def test_dynamic_defines_key_included(pandas_data):
 
 def test_dynamic_key_included_false_as_default(pandas_data):
     model = PandasToKafkaTransformer(pandas_data, "MyRecord",
-                                     key_fields=['key_field'])
+                                     key_fields={'key_field'})
     record = model.from_pandas(pandas_data)[0]
     assert not record.key_included
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,7 +18,7 @@ from pandas._testing import assert_frame_equal
 import pytest
 
 import py2k.models
-from py2k.models import KafkaModel, DynamicKafkaModel
+from py2k.models import KafkaRecord, PandasToKafkaTransformer
 
 
 def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
@@ -28,9 +28,9 @@ def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
     optional_fields = ['field4']
 
     params = ANY, model_name, fields_defaults, types_defaults, optional_fields
-    DynamicKafkaModel(*params)
+    PandasToKafkaTransformer(*params)
 
-    params_to_call = *params, KafkaModel
+    params_to_call = *params, KafkaRecord
     model_creator_class.assert_called_with(*params_to_call)
 
 
@@ -38,15 +38,15 @@ def test_dynamic_model_creates_creator_from_dataframe(model_creator_class):
     df = pd.DataFrame({'a': [1, 2], 'b': ["bla", "alb"]})
 
     params = df, ANY, ANY, ANY, ANY
-    DynamicKafkaModel(*params)
+    PandasToKafkaTransformer(*params)
 
-    params_to_call = *params, KafkaModel
+    params_to_call = *params, KafkaRecord
     called_df, *_ = called_args(model_creator_class, len(params_to_call))
     assert_frame_equal(df, called_df)
 
 
 def test_user_defines_model_without_key():
-    class MyRecord(KafkaModel):
+    class MyRecord(KafkaRecord):
         value_1: str
         value_2: int
 
@@ -59,7 +59,7 @@ def test_user_defines_model_without_key():
 
 
 def test_user_defines_model_with_one_key(pandas_data):
-    class MyRecord(KafkaModel):
+    class MyRecord(KafkaRecord):
         value_1: str
         key_field: str
         __key_fields__ = ['key_field']
@@ -69,23 +69,23 @@ def test_user_defines_model_with_one_key(pandas_data):
 
 
 def test_dynamic_defines_key_fields(pandas_data):
-    model = DynamicKafkaModel(pandas_data, "MyRecord",
-                              key_fields=['key_field'])
+    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
+                                     key_fields=['key_field'])
     record = model.from_pandas(pandas_data)[0]
     assert record.key_fields == ['key_field']
 
 
 def test_dynamic_defines_key_included(pandas_data):
-    model = DynamicKafkaModel(pandas_data, "MyRecord",
-                              key_fields=['key_field'],
-                              key_included=True)
+    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
+                                     key_fields=['key_field'],
+                                     key_included=True)
     record = model.from_pandas(pandas_data)[0]
     assert record.key_included
 
 
 def test_dynamic_key_included_false_as_default(pandas_data):
-    model = DynamicKafkaModel(pandas_data, "MyRecord",
-                              key_fields=['key_field'])
+    model = PandasToKafkaTransformer(pandas_data, "MyRecord",
+                                     key_fields=['key_field'])
     record = model.from_pandas(pandas_data)[0]
     assert not record.key_included
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,8 +17,8 @@ import pandas as pd
 from pandas._testing import assert_frame_equal
 import pytest
 
-import py2k.models
-from py2k.models import KafkaRecord, PandasToRecordsTransformer
+import py2k.record
+from py2k.record import KafkaRecord, PandasToRecordsTransformer
 
 
 def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
@@ -30,7 +30,7 @@ def test_dynamic_model_creates_pandas_model_creator(model_creator_class):
     params = ANY, model_name, fields_defaults, types_defaults, optional_fields
     PandasToRecordsTransformer(*params)
 
-    params_to_call = *params, KafkaRecord
+    params_to_call = *params, ANY
     model_creator_class.assert_called_with(*params_to_call)
 
 
@@ -80,14 +80,14 @@ def test_dynamic_defines_key_included(pandas_data):
                                        key_fields={'key_field'},
                                        include_key=True)
     record = model.from_pandas(pandas_data)[0]
-    assert record.key_included
+    assert record.include_key
 
 
 def test_dynamic_key_included_false_as_default(pandas_data):
     model = PandasToRecordsTransformer(pandas_data, "MyRecord",
                                        key_fields={'key_field'})
     record = model.from_pandas(pandas_data)[0]
-    assert not record.key_included
+    assert not record.include_key
 
 
 @pytest.fixture
@@ -107,7 +107,7 @@ def model_creator():
 def model_creator_class(monkeypatch, model_creator):
     model_creator_class = MagicMock()
     model_creator_class.return_value = model_creator
-    monkeypatch.setattr(py2k.models,
+    monkeypatch.setattr(py2k.record,
                         'PandasModelCreator', model_creator_class)
     return model_creator_class
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,129 @@
+# Copyright 2021 ABSA Group Limited
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+
+import pandas as pd
+import pytest
+
+import py2k.serializer
+from py2k.models import KafkaModel
+from py2k.serializer import KafkaSerializer
+
+
+class ParamMock:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def test_schema_string_of_value_serializer(serializer_without_key):
+    value_serializer = serializer_without_key.value_serializer()
+
+    schema = json.loads(value_serializer.kwargs.get('schema_str'))
+    expected_schema = {
+        'fields': [{'name': 'Field', 'type': 'string'}],
+        'name': 'ModelResult',
+        'namespace': 'python.kafka.modelresult',
+        'type': 'record'
+    }
+    assert schema == expected_schema
+
+
+def test_key_serializer_none_if_no_key_fiedls(serializer_without_key):
+    key_serializer = serializer_without_key.key_serializer()
+    assert key_serializer is None
+
+
+def test_schema_string_of_key_serializer(serializer_with_key):
+    key_serializer = serializer_with_key.key_serializer()
+    schema = json.loads(key_serializer.kwargs.get('schema_str'))
+
+    expected_schema = {
+        'fields': [{'name': 'Key', 'type': 'string'}],
+        'name': 'ModelResultKey',
+        'namespace': 'python.kafka.modelresult',
+        'type': 'record'
+    }
+    assert schema == expected_schema
+
+
+def test_schema_string_of_multy_key_serializer(serializer_with_multiple_key):
+    key_serializer = serializer_with_multiple_key.key_serializer()
+    schema = json.loads(key_serializer.kwargs.get('schema_str'))
+
+    expected_schema = {
+        'fields': [{'name': 'Key1', 'type': 'string'},
+                   {'name': 'Key2', 'type': 'string'}],
+        'name': 'ModelResultKey',
+        'namespace': 'python.kafka.modelresult',
+        'type': 'record'
+    }
+    assert schema == expected_schema
+
+
+@pytest.fixture
+def serializer_without_key(monkeypatch, schema_registry_config):
+    monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
+
+    class ModelResult(KafkaModel):
+        Field: str
+
+    df = pd.DataFrame({'Field': ['field_value']})
+    record = ModelResult.from_pandas(df)[0]
+
+    return KafkaSerializer(record, schema_registry_config)
+
+
+@pytest.fixture
+def serializer_with_key(monkeypatch, schema_registry_config):
+    monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
+
+    class ModelResult(KafkaModel):
+        __key_fields__ = ['Key']
+        Field: str
+        Key: str
+
+    df = pd.DataFrame({'Field': ['field_value'], 'Key': ['key_value']})
+    record = ModelResult.from_pandas(df)[0]
+
+    return KafkaSerializer(record, schema_registry_config)
+
+
+@pytest.fixture
+def serializer_with_multiple_key(monkeypatch, schema_registry_config):
+    monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
+
+    class ModelResult(KafkaModel):
+        __key_fields__ = ['Key1', 'Key2']
+        Field: str
+        Key1: str
+        Key2: str
+
+    df = pd.DataFrame({
+        'Field': ['field_value'],
+        'Key1': ['key1_value'],
+        'Key2': ['key2_value']
+    })
+    record = ModelResult.from_pandas(df)[0]
+
+    return KafkaSerializer(record, schema_registry_config)
+
+
+@pytest.fixture
+def schema_registry_config():
+    return {
+      'url': "http://test.schema.registry"
+    }

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -120,7 +120,7 @@ def serializer_with_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
     class ModelResult(KafkaRecord):
-        __key_fields__ = ['Key']
+        __key_fields__ = {'Key'}
         Field: str
         Key: str
 
@@ -135,7 +135,7 @@ def serializer_with_multiple_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
     class ModelResult(KafkaRecord):
-        __key_fields__ = ['Key1', 'Key2']
+        __key_fields__ = {'Key1', 'Key2'}
         Field: str
         Key1: str
         Key2: str
@@ -155,7 +155,7 @@ def serializer_key_included(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
     class ModelResult(KafkaRecord):
-        __key_fields__ = ['Key1', 'Key2']
+        __key_fields__ = {'Key1', 'Key2'}
         __key_included__ = True
         Field: str
         Key1: str

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -19,7 +19,7 @@ import pandas as pd
 import pytest
 
 import py2k.serializer
-from py2k.models import KafkaModel
+from py2k.models import KafkaRecord
 from py2k.serializer import KafkaSerializer
 
 
@@ -106,7 +106,7 @@ def test_value_serializer_with_key_when_specified(serializer_key_included):
 def serializer_without_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         Field: str
 
     df = pd.DataFrame({'Field': ['field_value']})
@@ -119,7 +119,7 @@ def serializer_without_key(monkeypatch, schema_registry_config):
 def serializer_with_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         __key_fields__ = ['Key']
         Field: str
         Key: str
@@ -134,7 +134,7 @@ def serializer_with_key(monkeypatch, schema_registry_config):
 def serializer_with_multiple_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         __key_fields__ = ['Key1', 'Key2']
         Field: str
         Key1: str
@@ -154,7 +154,7 @@ def serializer_with_multiple_key(monkeypatch, schema_registry_config):
 def serializer_key_included(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)
 
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         __key_fields__ = ['Key1', 'Key2']
         __key_included__ = True
         Field: str

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -19,7 +19,7 @@ import pandas as pd
 import pytest
 
 import py2k.serializer
-from py2k.models import KafkaRecord
+from py2k.record import KafkaRecord
 from py2k.serializer import KafkaSerializer
 
 

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -156,7 +156,7 @@ def serializer_key_included(monkeypatch, schema_registry_config):
 
     class ModelResult(KafkaRecord):
         __key_fields__ = {'Key1', 'Key2'}
-        __key_included__ = True
+        __include_key__ = True
         Field: str
         Key1: str
         Key2: str

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -74,6 +74,19 @@ def test_schema_string_of_multy_key_serializer(serializer_with_multiple_key):
     assert schema == expected_schema
 
 
+def test_value_serializer_without_key_by_default(serializer_with_multiple_key):
+    value_serializer = serializer_with_multiple_key.value_serializer()
+
+    schema = json.loads(value_serializer.kwargs.get('schema_str'))
+    expected_schema = {
+        'fields': [{'name': 'Field', 'type': 'string'}],
+        'name': 'ModelResult',
+        'namespace': 'python.kafka.modelresult',
+        'type': 'record'
+    }
+    assert schema == expected_schema
+
+
 @pytest.fixture
 def serializer_without_key(monkeypatch, schema_registry_config):
     monkeypatch.setattr(py2k.serializer, 'AvroSerializer', ParamMock)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -84,7 +84,7 @@ def data_class(raw_input):
 @pytest.fixture
 def data_class_with_key(raw_input):
     class ModelResult(KafkaRecord):
-        __key_fields__ = ['Customerkey']
+        __key_fields__ = {'Customerkey'}
         Customerkey: str
         Predictedvalue: float
         Timesince: Optional[int]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -43,7 +43,7 @@ def raw_input():
 
 
 @pytest.fixture
-def serialized_first_input():
+def first_value_dict_with_key():
     return {
         'Customerkey': 'Adam',
         'Predictedvalue': 123.22,
@@ -51,6 +51,21 @@ def serialized_first_input():
         'Applicableto': '2020-07',
         'Generationdate': '2020-03-20'
     }
+
+
+@pytest.fixture
+def first_value_dict_without_key():
+    return {
+        'Predictedvalue': 123.22,
+        'Timesince': 4,
+        'Applicableto': '2020-07',
+        'Generationdate': '2020-03-20'
+    }
+
+
+@pytest.fixture
+def first_key_dict():
+    return {'Customerkey': 'Adam'}
 
 
 @pytest.fixture
@@ -119,9 +134,9 @@ def test_pandas_serializer(pandas_dataframe, data_class):
 
 
 def test_pushes_one_item_of_model_data(monkeypatch, data_class_with_key,
-                                       serialized_first_input):
+                                       first_value_dict_without_key,
+                                       first_key_dict):
     topic = "DUMMY_TOPIC"
-    key = "Customerkey"
 
     one_item_list = data_class_with_key[:1]
 
@@ -136,16 +151,16 @@ def test_pushes_one_item_of_model_data(monkeypatch, data_class_with_key,
     writer = KafkaWriter(topic, {}, {})
     writer.write(one_item_list)
 
-    expected_key = {key: serialized_first_input[key]}
+    expected_key = first_key_dict
 
     producer.produce.assert_called_with(
-        topic=topic, key=expected_key, value=serialized_first_input,
+        topic=topic, key=expected_key, value=first_value_dict_without_key,
         on_delivery=ANY)
     producer.poll.assert_called_with(0)
 
 
 def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class,
-                                                   serialized_first_input):
+                                                   first_value_dict_with_key):
     topic = "DUMMY_TOPIC"
     one_item_list = data_class[:1]
 
@@ -161,5 +176,5 @@ def test_pushes_one_item_of_model_data_without_key(monkeypatch, data_class,
     writer.write(one_item_list)
 
     producer.produce.assert_called_with(
-        topic=topic, key=None, value=serialized_first_input, on_delivery=ANY)
+        topic=topic, key=None, value=first_value_dict_with_key, on_delivery=ANY)
     producer.poll.assert_called_with(0)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -22,7 +22,7 @@ import pytest
 import py2k.producer_config
 import py2k.producer
 import py2k.serializer
-from py2k.models import KafkaModel
+from py2k.models import KafkaRecord
 from py2k.writer import KafkaWriter
 
 
@@ -70,7 +70,7 @@ def first_key_dict():
 
 @pytest.fixture
 def data_class(raw_input):
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         Customerkey: str
         Predictedvalue: float
         Timesince: Optional[int]
@@ -83,7 +83,7 @@ def data_class(raw_input):
 
 @pytest.fixture
 def data_class_with_key(raw_input):
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         __key_fields__ = ['Customerkey']
         Customerkey: str
         Predictedvalue: float
@@ -134,7 +134,7 @@ def test_content(data_class):
 
 
 def test_pandas_serializer(pandas_dataframe, data_class):
-    class ModelResult(KafkaModel):
+    class ModelResult(KafkaRecord):
         Customerkey: str
         Predictedvalue: float
         Timesince: int

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -22,7 +22,7 @@ import pytest
 import py2k.producer_config
 import py2k.producer
 import py2k.serializer
-from py2k.models import KafkaRecord
+from py2k.record import KafkaRecord
 from py2k.writer import KafkaWriter
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Adhering to Kafka and Avro parlance by renaming:
   - models module -> record
   - KafkaModel -> KafkaRecord
   - DynamicPandasModel  -> PandasToRecordsTransformer
   - item -> record
- Move schema knowledge to KafkaRecord
- Introduce `__key_fields__` in KafkaRecord to enable specifying which fields are part of the key
- Introduce `__include_key__` in KafkaRecored to enable specifying whether __key_fields__ should be part of the value message

## Related issue number

#40 #39 #31 #20 #34 #32 #35 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI and coverage remains at 100%
- [ ] Documentation reflects the changes where applicable
- [ ] Version bumped if necessary
- [ ] Changes are documented in [HISTORY.md](../HISTORY.md)
