### PR TITLE
Bugfix - bool deafault values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,6 @@ dist: clean ## builds source and wheel package
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
+
+check-license:
+	apache-license-check --copyright "2021 ABSA Group Limited" py2k/* tests/*.py tests/utils

--- a/py2k/utils/__init__.py
+++ b/py2k/utils/__init__.py
@@ -28,9 +28,14 @@ def process_properties(schema: Dict[str, Any]) -> Dict[str, Any]:
     """
     fields: List[Dict[str, Any]] = []
 
-    json2avro = {
+    json2avro_types = {
         'number': 'double',
         'integer': 'int'
+    }
+
+    python2avro_defaults = {
+        False: 'false',
+        True: 'true'
     }
 
     for name, value in schema['properties'].items():
@@ -39,7 +44,12 @@ def process_properties(schema: Dict[str, Any]) -> Dict[str, Any]:
             value['name'] = name
 
             json_type = value['type']
-            value['type'] = json2avro.get(json_type, json_type)
+            value['type'] = json2avro_types.get(json_type, json_type)
+
+            if value.get('default') is not None:
+                default = value['default']
+                value['default'] = python2avro_defaults.get(default, default)
+
         finally:
             fields.append(value)
     schema['fields'] = fields

--- a/py2k/utils/__init__.py
+++ b/py2k/utils/__init__.py
@@ -27,13 +27,19 @@ def process_properties(schema: Dict[str, Any]) -> Dict[str, Any]:
     :rtype: Dict[str, Any]
     """
     fields: List[Dict[str, Any]] = []
-    for value in schema['properties'].values():
+
+    json2avro = {
+        'number': 'double',
+        'integer': 'int'
+    }
+
+    for name, value in schema['properties'].items():
         try:
-            value['name'] = value.pop('title')
-            if value['type'] == 'number':
-                value['type'] = 'double'
-            if value['type'] == 'integer':
-                value['type'] = 'int'
+            value.pop('title')
+            value['name'] = name
+
+            json_type = value['type']
+            value['type'] = json2avro.get(json_type, json_type)
         finally:
             fields.append(value)
     schema['fields'] = fields

--- a/tests/test_dynamic_model.py
+++ b/tests/test_dynamic_model.py
@@ -233,6 +233,12 @@ def _assert_schema_defaults(sample_record, expected, by_name=True):
             "boolean": bool
         }.get(type_name)
 
+    def python_val_to_avro(val):
+        return {
+            False: 'false',
+            True: 'true'
+        }.get(val, val)
+
     # actual records after transformed
     actual = json.loads(sample_record.schema_json())
 
@@ -245,7 +251,8 @@ def _assert_schema_defaults(sample_record, expected, by_name=True):
             expected_default = expected.get(
                 json_to_python_type(field.get("type")))
 
-        assert expected_default == actual_default
+        expected_default = python_val_to_avro(expected_default)
+        assert actual_default == expected_default
 
 
 def _assert_schema_types(sample_record, expected):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,17 @@
+# Copyright 2021 ABSA Group Limited
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
 import pytest

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,43 @@
+import pytest
+from pydantic.main import create_model
+
+from py2k.record import KafkaRecord
+
+
+@pytest.mark.parametrize(
+    'python_type,avro_type',
+    [
+        (bool, 'boolean'),
+        (int, 'int'),
+        (str, 'string'),
+        (float, 'double')
+    ]
+)
+def test_schema_without_default(python_type, avro_type):
+    MyRecord = create_model('MyRecord', a=(python_type, ...),
+                            __base__=KafkaRecord)
+    schema = MyRecord(a=True).schema()
+
+    expected = {
+        'type': 'record',
+        'name': 'MyRecord',
+        'namespace': 'python.kafka.myrecord',
+        'fields': [
+            {'type': avro_type, 'name': 'a'},
+        ]
+    }
+
+    assert schema == expected
+
+
+@pytest.mark.parametrize(
+    'name',
+    ['a', 'A', 'lower', 'Upper', 'camelCase', 'snake_case', 'WeirD_miSh_mAsh']
+)
+def test_field_name_unchanged(name):
+    field_def = {name: 'default_string'}
+    MyRecord = create_model('MyRecord', __base__=KafkaRecord, **field_def)
+    schema = MyRecord(a=True).schema()
+
+    name_in_schema = schema['fields'][0]['name']
+    assert name_in_schema == name

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -22,22 +22,37 @@ def test_top_level_record_schema():
     assert schema == expected
 
 
-@pytest.mark.parametrize(
-    'python_type,avro_type',
-    [
-        (bool, 'boolean'),
-        (int, 'int'),
-        (str, 'string'),
-        (float, 'double')
-    ]
-)
+_types_to_test = [
+    (bool, 'boolean'),
+    (int, 'int'),
+    (str, 'string'),
+    (float, 'double'),
+]
+
+
+@pytest.mark.parametrize('python_type,avro_type', _types_to_test)
 def test_field_type(python_type, avro_type):
     MyRecord = create_model('MyRecord', a=(python_type, ...),
                             __base__=KafkaRecord)
-    schema = MyRecord(a=python_type(1)).schema()
+
+    record = MyRecord(a=python_type(1))
+    schema = record.schema()
     field_type = schema['fields'][0]['type']
 
     assert field_type == avro_type
+
+
+@pytest.mark.parametrize('python_type,avro_type', _types_to_test)
+def test_optional_field_type(python_type, avro_type):
+    MyRecord = create_model('MyRecord',
+                            a=(Optional[python_type], None),
+                            __base__=KafkaRecord)
+
+    record = MyRecord()
+    schema = record.schema()
+    field_type = schema['fields'][0]['type']
+
+    assert field_type == ['null', avro_type]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,25 @@
+from typing import Optional
+
 import pytest
 from pydantic.main import create_model
 
 from py2k.record import KafkaRecord
+
+
+def test_top_level_record_schema():
+    MyRecord = create_model('MyRecord', a=(int, ...), __base__=KafkaRecord)
+    schema = MyRecord(a=10).schema()
+
+    expected = {
+        'type': 'record',
+        'name': 'MyRecord',
+        'namespace': 'python.kafka.myrecord',
+        'fields': [
+            {'type': 'int', 'name': 'a'},
+        ]
+    }
+
+    assert schema == expected
 
 
 @pytest.mark.parametrize(
@@ -13,21 +31,13 @@ from py2k.record import KafkaRecord
         (float, 'double')
     ]
 )
-def test_schema_without_default(python_type, avro_type):
+def test_field_type(python_type, avro_type):
     MyRecord = create_model('MyRecord', a=(python_type, ...),
                             __base__=KafkaRecord)
-    schema = MyRecord(a=True).schema()
+    schema = MyRecord(a=python_type(1)).schema()
+    field_type = schema['fields'][0]['type']
 
-    expected = {
-        'type': 'record',
-        'name': 'MyRecord',
-        'namespace': 'python.kafka.myrecord',
-        'fields': [
-            {'type': avro_type, 'name': 'a'},
-        ]
-    }
-
-    assert schema == expected
+    assert field_type == avro_type
 
 
 @pytest.mark.parametrize(
@@ -41,3 +51,21 @@ def test_field_name_unchanged(name):
 
     name_in_schema = schema['fields'][0]['name']
     assert name_in_schema == name
+
+
+@pytest.mark.parametrize(
+    'python_value,avro_value',
+    [
+        (True, 'true'),
+        (False, 'false'),
+        (10, 10),
+        ("dummy", 'dummy'),
+        (10.2, 10.2)
+    ]
+)
+def test_field_with_default(python_value, avro_value):
+    MyRecord = create_model('MyRecord', a=python_value,  __base__=KafkaRecord)
+    schema = MyRecord().schema()
+    default_value = schema['fields'][0]['default']
+
+    assert default_value == avro_value


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- Generate properly Avro default values - python False object -> 'false'
- Fix enforcing uppercased first letter when field is defined manually
- license check to Makefile `make check-license`

## Related issue number

closes #44, closes #42

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI and coverage remains at 100%
- [x] Documentation reflects the changes where applicable
- [ ] Version bumped if necessary
- [ ] Changes are documented in [release_notes.md](../docs/release_notes.md)
