### PR TITLE
✨ Support for dynamic creation to return an iterator

### DIFF
--- a/py2k/record.py
+++ b/py2k/record.py
@@ -17,7 +17,7 @@ import itertools
 import json
 import warnings
 from copy import deepcopy
-from typing import Any, Dict, List, Type, Set
+from typing import Any, Dict, List, Type, Set, Iterator
 
 import pandas as pd
 from pydantic import BaseModel
@@ -43,7 +43,7 @@ class KafkaRecord(BaseModel):
         return []
 
     @classmethod
-    def iter_from_pandas(cls, df: pd.DataFrame):
+    def iter_from_pandas(cls, df: pd.DataFrame) -> Iterator['KafkaRecord']:
         for record in df.to_dict('records'):
             yield cls(**record)
 
@@ -171,7 +171,7 @@ class PandasToRecordsTransformer:
             df (pd.DataFrame): Pandas dataframe. Defaults to None.
 
         Returns:
-            [List[KafkaModel]]: serialized list of KafkaModel objects
+            List[KafkaModel]: serialized list of KafkaModel objects
 
         Examples:
             >>> record_transformer = PandasToRecordsTransformer(df=df,
@@ -188,20 +188,20 @@ class PandasToRecordsTransformer:
 
         return self._model.from_pandas(self._df)
 
-    def iter_from_pandas(self, df: pd.DataFrame):
+    def iter_from_pandas(self, df: pd.DataFrame = None):
         """Creates iterator of KafkaModel objects from a pandas DataFrame
 
-                Args:
-                    df (pd.DataFrame): Pandas dataframe. Defaults to None.
+        Args:
+            df (pd.DataFrame): Pandas dataframe. Defaults to None.
 
-                Returns:
-                    [List[KafkaModel]]: serialized list of KafkaModel objects
+        Returns:
+            Iterator[KafkaModel]: serialized list of KafkaModel objects
 
-                Examples:
-                    >>> record_transformer = PandasToRecordsTransformer(df=df,
-                                                                        record_name='KafkaRecord')
-                    >>> record_transformer.iter_from_pandas()
-                """
+        Examples:
+            >>> record_transformer = PandasToRecordsTransformer(df=df,
+                                                                record_name='KafkaRecord')
+            >>> record_transformer.iter_from_pandas()
+        """
         if df is not None:
             return self._model.iter_from_pandas(df)
 

--- a/py2k/record.py
+++ b/py2k/record.py
@@ -33,19 +33,17 @@ class KafkaRecord(BaseModel):
 
     @classmethod
     def from_pandas(cls, df: pd.DataFrame) -> List['KafkaRecord']:
-        records = df.to_dict('records')
-
-        if records:
-            return [cls(**item) for item in records]
-
-        warnings.warn(
-            "Unable to create kafka model from an empty dataframe.")
-        return []
+        return list(cls.iter_from_pandas(df))
 
     @classmethod
     def iter_from_pandas(cls, df: pd.DataFrame) -> Iterator['KafkaRecord']:
-        for record in df.to_dict('records'):
-            yield cls(**record)
+        records = df.to_dict('records')
+
+        if not records:
+            warnings.warn(
+                "Unable to create kafka model from an empty dataframe.")
+
+        return (cls(**item) for item in records)
 
     class Config:
         json_encoders = {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,6 +152,19 @@ def test_dynamic_defined_correct_iter(pandas_data, method_name, expected_type):
     assert isinstance(result, expected_type)
 
 
+@pytest.mark.parametrize(
+    'method_name',
+    ['from_pandas', 'iter_from_pandas']
+)
+def test_dynamic_creates_from_original_by_default(pandas_data, method_name):
+    model = PandasToRecordsTransformer(pandas_data, "MyRecord",
+                                       key_fields={'key_field'})
+
+    from_pandas_method = getattr(model, method_name)
+    record = list(from_pandas_method())[0]
+    assert not record.include_key
+
+
 @pytest.fixture
 def pandas_data():
     return pd.DataFrame({

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -165,6 +165,29 @@ def test_dynamic_creates_from_original_by_default(pandas_data, method_name):
     assert not record.include_key
 
 
+@pytest.mark.parametrize(
+    'method_name',
+    ['from_pandas', 'iter_from_pandas']
+)
+def test_empty_df_return_empty_iter(method_name):
+    class MyRecord(KafkaRecord):
+        value_1: str
+        value_2: int
+
+    df = pd.DataFrame({
+        'value_1': [],
+        'value_2': []
+    })
+    with pytest.warns(UserWarning) as warnings:
+        from_pandas_method = getattr(MyRecord, method_name)
+        records = list(from_pandas_method(df))
+
+    assert records == []
+    assert len(warnings) == 1
+    assert warnings[0].message.args[0] == "Unable to create kafka " \
+                                          "model from an empty dataframe."
+
+
 @pytest.fixture
 def pandas_data():
     return pd.DataFrame({


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- User can choose whether to return list (`from_pandas`) or iterator (`iter_from_pandas`)
- KafkaWriter was adjusted accordingly to accept any iterable in it's `write` method

## Related issue number

Close #61 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI and coverage remains at 100%
- [x] Documentation reflects the changes where applicable
- [ ] Version bumped if necessary
- [ ] Changes are documented in [release_notes.md](../docs/release_notes.md)
