### PR TITLE
Bugfix - Extract schema from whole dataframe

### DIFF
--- a/py2k/creators.py
+++ b/py2k/creators.py
@@ -98,13 +98,14 @@ class PandasModelCreator(ModelCreator):
         sample_record = {
             col: self._sample_col(col) for col in self._df.columns
         }
-
         return self._create_model(sample_record)
 
     def _sample_col(self, col):
-        return self._df[[col]]\
-                .dropna()\
-                .to_dict('records')[0][col]
+        without_na = self._df[col].dropna()
+        if without_na.empty:
+            return None
+
+        return without_na.tolist()[0]
 
     def _create_model(self, record):
         def field_definition(field_name: str, field_value: Any):

--- a/py2k/creators.py
+++ b/py2k/creators.py
@@ -91,14 +91,20 @@ class PandasModelCreator(ModelCreator):
         self._base = base
 
     def create(self):
-        records_as_dict_list = self._df.to_dict('records')
-        if records_as_dict_list:
-            sample_record = records_as_dict_list[0]
-            model = self._create_model(sample_record)
-            return model
-        else:
+        if self._df.empty:
             raise ValueError(
                 "Unable to create kafka model from an empty dataframe.")
+
+        sample_record = {
+            col: self._sample_col(col) for col in self._df.columns
+        }
+
+        return self._create_model(sample_record)
+
+    def _sample_col(self, col):
+        return self._df[[col]]\
+                .dropna()\
+                .to_dict('records')[0][col]
 
     def _create_model(self, record):
         def field_definition(field_name: str, field_value: Any):

--- a/py2k/producer.py
+++ b/py2k/producer.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from confluent_kafka import SerializingProducer
-from confluent_kafka import KafkaError, Message
+from confluent_kafka import SerializingProducer, KafkaError, Message
 
 
 class KafkaProducer:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -188,6 +188,21 @@ def test_empty_df_return_empty_iter(method_name):
                                           "model from an empty dataframe."
 
 
+@pytest.mark.parametrize(
+    'method_name',
+    ['from_pandas', 'iter_from_pandas']
+)
+def test_dynamic_with_null_row(method_name):
+    df = pd.DataFrame({'a': [None, "bla"]})
+
+    model = PandasToRecordsTransformer(df, "MyRecord", optional_fields=['a'])
+
+    from_pandas_method = getattr(model, method_name)
+    records = list(from_pandas_method())
+    assert records[0].a is None
+    assert records[1].a == "bla"
+
+
 @pytest.fixture
 def pandas_data():
     return pd.DataFrame({

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,7 +15,6 @@ from collections import Iterator
 from unittest.mock import MagicMock, ANY
 import datetime as dt
 
-import numpy as np
 import pandas as pd
 from pandas._testing import assert_frame_equal
 import pytest
@@ -192,7 +191,8 @@ def test_empty_df_return_empty_iter(method_name):
 
 @pytest.mark.parametrize(
     'value',
-    ['bla', 12, -20., False, dt.date(2020, 1, 1), dt.datetime(2020, 1, 1, 0, 0, 0)],
+    ['bla', 12, -20., False, dt.date(2020, 1, 1),
+     dt.datetime(2020, 1, 1, 0, 0, 0)],
     ids=['str', 'int', 'float', 'bool', 'date', 'datetime']
 )
 def test_dynamic_with_null_first_row(value):
@@ -203,6 +203,20 @@ def test_dynamic_with_null_first_row(value):
     records = model.from_pandas()
     assert pd.isna(records[0].a)  # pd.isna(None) == true
     assert records[1].a == value
+
+
+def test_one_column_all_nulls():
+    df = pd.DataFrame({
+        'non_empty_col': [1, 2],
+        'empty_col': [None, None]
+    })
+
+    with pytest.raises(ValueError) as exception_info:
+        model = PandasToRecordsTransformer(df, "MyRecord",
+                                           optional_fields=['a'])
+        model.from_pandas()
+
+    assert "Invalid type for field 'empty_col'" in str(exception_info.value)
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 from collections import Iterator
 from unittest.mock import MagicMock, ANY
+import datetime as dt
 
+import numpy as np
 import pandas as pd
 from pandas._testing import assert_frame_equal
 import pytest
@@ -189,18 +191,18 @@ def test_empty_df_return_empty_iter(method_name):
 
 
 @pytest.mark.parametrize(
-    'method_name',
-    ['from_pandas', 'iter_from_pandas']
+    'value',
+    ['bla', 12, -20., False, dt.date(2020, 1, 1), dt.datetime(2020, 1, 1, 0, 0, 0)],
+    ids=['str', 'int', 'float', 'bool', 'date', 'datetime']
 )
-def test_dynamic_with_null_row(method_name):
-    df = pd.DataFrame({'a': [None, "bla"]})
+def test_dynamic_with_null_first_row(value):
+    df = pd.DataFrame({'a': [None, value]})
 
     model = PandasToRecordsTransformer(df, "MyRecord", optional_fields=['a'])
 
-    from_pandas_method = getattr(model, method_name)
-    records = list(from_pandas_method())
-    assert records[0].a is None
-    assert records[1].a == "bla"
+    records = model.from_pandas()
+    assert pd.isna(records[0].a)  # pd.isna(None) == true
+    assert records[1].a == value
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

The original implementation extracted schema only from the first row of the dataframe. Such behavior
caused errors when null values occurred in the first row.

Proposed implementation:
- finds the first non-null value for each column
- throws ValueError when all values are null

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI and coverage remains at 100%
- [ ] Documentation reflects the changes where applicable
- [ ] Version bumped if necessary
- [ ] Changes are documented in [release_notes.md](../docs/release_notes.md)
